### PR TITLE
Add "Done" action to the keyboard, so we can easily hide the keyboard.

### DIFF
--- a/lazydatepicker/src/main/res/layout/layout_lazy_date_picker.xml
+++ b/lazydatepicker/src/main/res/layout/layout_lazy_date_picker.xml
@@ -13,6 +13,7 @@
         android:digits="0123456789"
         android:inputType="number|none"
         android:textSize="0sp"
+        android:imeOptions="actionDone"
         tools:ignore="LabelFor,TextFields" />
 
     <LinearLayout


### PR DESCRIPTION
I find it annoying that there's no way to hide the keyboard (unless you programmatically do it in the code, or tap the device's back key), and the enter key doesn't do anything. So I add "android:imeOptions="actionDone"" to EditText, so that we can easily hide the keyboard when we tap "Done" instead of having to click the device's back key.